### PR TITLE
Added motion compensation feature to rslidar_pointcloud

### DIFF
--- a/rslidar_pointcloud/CMakeLists.txt
+++ b/rslidar_pointcloud/CMakeLists.txt
@@ -5,6 +5,7 @@ add_compile_options(-std=c++11)
 set(CMAKE_BUILD_TYPE Release)#RelWithDebInfo
 set(${PROJECT_NAME}_CATKIN_DEPS
     angles
+    eigen_conversions
     nodelet
     pcl_ros
     roscpp

--- a/rslidar_pointcloud/launch/rs_bpearl.launch
+++ b/rslidar_pointcloud/launch/rs_bpearl.launch
@@ -25,6 +25,7 @@
     <param name="intensity_mode" value="3"/>
     <param name="compensate_motion" value="false"/>
     <param name="fixed_frame" value="odom"/>
+    <param name="tf_wait_time" value="0.02"/>
   </node>
 
   <node name="rviz" pkg="rviz" type="rviz"  args="-d $(find rslidar_pointcloud)/rviz_cfg/rslidar.rviz" />

--- a/rslidar_pointcloud/launch/rs_bpearl.launch
+++ b/rslidar_pointcloud/launch/rs_bpearl.launch
@@ -23,6 +23,8 @@
     <param name="min_distance" value="0.1"/>
     <param name="resolution_type" value="0.5cm"/>
     <param name="intensity_mode" value="3"/>
+    <param name="compensate_motion" value="false"/>
+    <param name="fixed_frame" value="odom"/>
   </node>
 
   <node name="rviz" pkg="rviz" type="rviz"  args="-d $(find rslidar_pointcloud)/rviz_cfg/rslidar.rviz" />

--- a/rslidar_pointcloud/package.xml
+++ b/rslidar_pointcloud/package.xml
@@ -31,9 +31,11 @@
   <build_depend>roslaunch</build_depend>
   <build_depend>rostest</build_depend>
   <build_depend>tf2_ros</build_depend>
+  <build_depend>eigen_conversions</build_depend>
 
   <run_depend>angles</run_depend>
   <run_depend>nodelet</run_depend>
+  <run_depend>eigen_conversions</run_depend>
   <run_depend>pcl_ros</run_depend>
   <run_depend>pluginlib</run_depend>
   <!-- <run_depend>python-yaml</run_depend> -->

--- a/rslidar_pointcloud/src/convert.cc
+++ b/rslidar_pointcloud/src/convert.cc
@@ -31,6 +31,7 @@ Convert::Convert(ros::NodeHandle node, ros::NodeHandle private_nh) :
   private_nh.param("model", model, std::string("RS16"));
   private_nh.param("compensate_motion", compensate_motion_, false);
   private_nh.param("fixed_frame", fixed_frame_, std::string(""));
+  private_nh.param("tf_wait_time", tf_wait_time_, 0.02);
 
   ROS_INFO_STREAM("[cloud][convert] compensate motion: " << compensate_motion_);
   if (compensate_motion_) {
@@ -38,6 +39,7 @@ Convert::Convert(ros::NodeHandle node, ros::NodeHandle private_nh) :
       ROS_ERROR_STREAM("[cloud][convert] Motion compensation enabled but got empty fixed frame id");
     } else {
       ROS_INFO_STREAM("[cloud][convert] fixed frame: " << fixed_frame_);
+      ROS_INFO_STREAM("[cloud][convert] Tf wait time: " << tf_wait_time_);
     }
   }
 
@@ -102,7 +104,7 @@ void Convert::processScan(const rslidar_msgs::rslidarScan::ConstPtr& scanMsg)
                                                      scanMsg->header.frame_id, // Source frame.
                                                      scanMsg->packets[i].stamp,  // Source time.
                                                      fixed_frame_, // Fixed frame.
-                                                     ros::Duration(0.02));  // Wait time for transform.
+                                                     ros::Duration(tf_wait_time_));  // Wait time for transform.
         ROS_DEBUG_STREAM(tf_comp_stamped);
         tf::transformMsgToEigen(tf_comp_stamped.transform, tf_comp_eigen);
       }

--- a/rslidar_pointcloud/src/convert.cc
+++ b/rslidar_pointcloud/src/convert.cc
@@ -101,8 +101,9 @@ void Convert::processScan(const rslidar_msgs::rslidarScan::ConstPtr& scanMsg)
                                                 scanMsg->header.stamp,  // Target time.
                                                 scanMsg->header.frame_id, // Source frame.
                                                 scanMsg->packets[i].stamp,  // Source time.
-                                                fixed_frame_);  // Fixed frame.
-        ROS_INFO_STREAM(tf_comp_stamped);
+                                                fixed_frame_, // Fixed frame.
+                                                ros::Duration(0.02));  // Wait time for transform.
+        ROS_DEBUG_STREAM(tf_comp_stamped);
         tf::transformMsgToEigen(tf_comp_stamped.transform, tf_comp_eigen);
       }
       catch (tf2::TransformException &ex) {

--- a/rslidar_pointcloud/src/convert.cc
+++ b/rslidar_pointcloud/src/convert.cc
@@ -98,11 +98,11 @@ void Convert::processScan(const rslidar_msgs::rslidarScan::ConstPtr& scanMsg)
       tf_comp_eigen.setIdentity();
       try{
         tf_comp_stamped = tf_buffer_.lookupTransform(scanMsg->header.frame_id, // Target frame.
-                                                scanMsg->header.stamp,  // Target time.
-                                                scanMsg->header.frame_id, // Source frame.
-                                                scanMsg->packets[i].stamp,  // Source time.
-                                                fixed_frame_, // Fixed frame.
-                                                ros::Duration(0.02));  // Wait time for transform.
+                                                     scanMsg->header.stamp,  // Target time.
+                                                     scanMsg->header.frame_id, // Source frame.
+                                                     scanMsg->packets[i].stamp,  // Source time.
+                                                     fixed_frame_, // Fixed frame.
+                                                     ros::Duration(0.02));  // Wait time for transform.
         ROS_DEBUG_STREAM(tf_comp_stamped);
         tf::transformMsgToEigen(tf_comp_stamped.transform, tf_comp_eigen);
       }

--- a/rslidar_pointcloud/src/convert.h
+++ b/rslidar_pointcloud/src/convert.h
@@ -50,6 +50,7 @@ private:
   tf2_ros::TransformListener tf_listener_;
   bool compensate_motion_;
   std::string fixed_frame_;
+  double tf_wait_time_;
 };
 
 }  // namespace rslidar_pointcloud

--- a/rslidar_pointcloud/src/convert.h
+++ b/rslidar_pointcloud/src/convert.h
@@ -44,6 +44,12 @@ private:
   boost::shared_ptr<rslidar_rawdata::RawData> data_;
   ros::Subscriber rslidar_scan_;
   ros::Publisher output_;
+
+  // Motion compensation.
+  tf2_ros::Buffer tf_buffer_;
+  tf2_ros::TransformListener tf_listener_;
+  bool compensate_motion_;
+  std::string fixed_frame_;
 };
 
 }  // namespace rslidar_pointcloud

--- a/rslidar_pointcloud/src/rawdata.cc
+++ b/rslidar_pointcloud/src/rawdata.cc
@@ -827,7 +827,9 @@ int RawData::estimateTemperature(float Temper)
  *  @param pkt raw packet to unpack
  *  @param pc shared pointer to point cloud (points are appended)
  */
-void RawData::unpack(const rslidar_msgs::rslidarPacket& pkt, pcl::PointCloud<pcl::PointXYZI>::Ptr pointcloud)
+void RawData::unpack(const rslidar_msgs::rslidarPacket& pkt,
+                     pcl::PointCloud<pcl::PointXYZI>::Ptr pointcloud,
+                     const Eigen::Affine3f& tf_comp)
 {
   // check pkt header
   if (pkt.data[0] != 0x55 || pkt.data[1] != 0xAA || pkt.data[2] != 0x05 || pkt.data[3] != 0x0A)
@@ -837,7 +839,7 @@ void RawData::unpack(const rslidar_msgs::rslidarPacket& pkt, pcl::PointCloud<pcl
 
   if (numOfLasers == 32)
   {
-    unpack_RS32(pkt, pointcloud);
+    unpack_RS32(pkt, pointcloud, tf_comp);
     return;
   }
   float azimuth;  // 0.01 dgree
@@ -952,6 +954,7 @@ void RawData::unpack(const rslidar_msgs::rslidarPacket& pkt, pcl::PointCloud<pcl
                     Rx_ * this->sin_lookup_table_[arg_horiz_orginal];
           point.z = distance2 * this->sin_lookup_table_[arg_vert] + Rz_;
           point.intensity = intensity;
+          point = pcl::transformPoint(point, tf_comp);
           pointcloud->at(2 * this->block_num + firing, dsr) = point;
         }
       }
@@ -959,7 +962,9 @@ void RawData::unpack(const rslidar_msgs::rslidarPacket& pkt, pcl::PointCloud<pcl
   }
 }
 
-void RawData::unpack_RS32(const rslidar_msgs::rslidarPacket& pkt, pcl::PointCloud<pcl::PointXYZI>::Ptr pointcloud)
+void RawData::unpack_RS32(const rslidar_msgs::rslidarPacket& pkt,
+                          pcl::PointCloud<pcl::PointXYZI>::Ptr pointcloud,
+                          const Eigen::Affine3f& tf_comp)
 {
   float azimuth;  // 0.01 dgree
   float intensity;
@@ -1076,6 +1081,7 @@ void RawData::unpack_RS32(const rslidar_msgs::rslidarPacket& pkt, pcl::PointClou
                     Rx_ * this->sin_lookup_table_[arg_horiz_orginal];
           point.z = distance2 * this->sin_lookup_table_[arg_vert] + Rz_;
           point.intensity = intensity;
+          point = pcl::transformPoint(point, tf_comp);
           pointcloud->at(this->block_num, dsr) = point;
         }
       }

--- a/rslidar_pointcloud/src/rawdata.h
+++ b/rslidar_pointcloud/src/rawdata.h
@@ -136,10 +136,14 @@ public:
   void loadConfigFile(ros::NodeHandle node, ros::NodeHandle private_nh);
 
   /*unpack the RS16 UDP packet and opuput PCL PointXYZI type*/
-  void unpack(const rslidar_msgs::rslidarPacket& pkt, pcl::PointCloud<pcl::PointXYZI>::Ptr pointcloud);
+  void unpack(const rslidar_msgs::rslidarPacket& pkt,
+              pcl::PointCloud<pcl::PointXYZI>::Ptr pointcloud,
+              const Eigen::Affine3f& tf_comp = Eigen::Affine3f::Identity());
 
   /*unpack the RS32 UDP packet and opuput PCL PointXYZI type*/
-  void unpack_RS32(const rslidar_msgs::rslidarPacket& pkt, pcl::PointCloud<pcl::PointXYZI>::Ptr pointcloud);
+  void unpack_RS32(const rslidar_msgs::rslidarPacket& pkt,
+                   pcl::PointCloud<pcl::PointXYZI>::Ptr pointcloud,
+                   const Eigen::Affine3f& tf_comp = Eigen::Affine3f::Identity());
 
   /*compute temperature*/
   float computeTemperature(unsigned char bit1, unsigned char bit2);


### PR DESCRIPTION
I have added motion compensation to the `rslidar_pointcloud` node. What it does is that it compensates for potential motion of the sensor between arrival of a scan package and publication of the point cloud.
This is achieved by querying the TF tree for motion of the rslidar frame relative to a given fixed frame.

We have experimentally tested that this works using a BPearl on our legged robot.
The following screenshot is taken from RViz, while our robot was walking up a single step onto a flat podium. The sensor is mounted in the front of the robot, scanning the ground. 
This clearly shows that, without motion compensation, there is a serious "cut" in the point cloud, while the ground is flat with motion compensation. 

![motion_compensation_labelled](https://user-images.githubusercontent.com/5803027/73175977-af512d80-410b-11ea-9cd4-a17ecf912942.png)

This introduces a new dependency on `eigen_conversions`, which is installed with ROS per default. 